### PR TITLE
Port calc parser from babelstats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 /doc/*
 *.trace
 *~
+_build/
+rebar.lock
+src/calc_lexer.erl
+src/calc_parser.erl

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ This library contains the following functions:
 ## Return a list of values  
   
 * moving_average  
-* correlation   
-* correlation_matrix 
+* correlation
+* correlation_matrix
+
+In addition to statistics, mathex can parse and evaluate simple algebraic
+expressions.  See `mathex_calc:eval/1` for evaluating a string expression and
+`mathex_calc:calculate/1` for applying an expression to a list of dated values.
   
 Most of these are well documented elsewhere except maybe the  
 correlation_matrix.  

--- a/src/calc_lexer.xrl
+++ b/src/calc_lexer.xrl
@@ -1,0 +1,32 @@
+Definitions.
+
+Digit           = [0-9]
+WS 	  	= ([\000-\s]|%.*)
+Plus	  	= \+
+Minus	  	= \-
+Multiply 	= \*
+Divide		= \/
+Power		= \^
+Function	= [A-Za-z]
+Open		= \(
+Close		= \)
+Op		= [\+|\^|\*|\/]
+
+Rules.
+
+\-?{Digit}+		  		    : {token, {float, TokenLine, convert_to_float(TokenChars)}}.
+\-?{Digit}+\.{Digit}+((E|e)(\+|\-)?{D}+)?   : {token, {float, TokenLine, list_to_float(TokenChars)}}.
+{Plus}			           	    : {token, {add, TokenLine, list_to_atom(TokenChars)}}.
+{Minus}		           	    	    : {token, {minus, TokenLine, list_to_atom(TokenChars)}}.
+{Multiply}		           	    : {token, {multiply, TokenLine, list_to_atom(TokenChars)}}.
+{Divide}	  	           	    : {token, {divide, TokenLine, list_to_atom(TokenChars)}}.
+{Power}			           	    : {token, {power, TokenLine, list_to_atom(TokenChars)}}.
+{Open}			           	    : {token, {open, TokenLine, list_to_atom(TokenChars)}}.
+{Close}			           	    : {token, {close, TokenLine, list_to_atom(TokenChars)}}.
+{Function}+                        	    : {token, {fn, TokenLine, list_to_atom(TokenChars)}}.
+{WS}+    		           	    : skip_token.
+
+Erlang code.
+
+convert_to_float(List) ->
+    list_to_float(List++".0000000").

--- a/src/calc_parser.yrl
+++ b/src/calc_parser.yrl
@@ -1,0 +1,95 @@
+Nonterminals
+	eval expr term factor.
+
+Terminals
+	open close add minus multiply divide float power fn.
+
+Rootsymbol eval.
+
+Left 100 float.
+Left 200 open.
+Left 300 close.
+Left 400 fn.
+Left 500 add.
+Left 600 minus.
+Left 700 multiply.
+Left 800 divide.
+Left 900 power.
+
+eval -> expr		     : '$1'.
+
+expr -> expr add term	     : add('$1','$3').
+expr -> expr minus term	     : subtract('$1','$3').
+expr -> term                 : '$1'.
+
+term -> term multiply factor : multiply('$1','$3').
+term -> term divide   factor : divide('$1','$3').
+term -> term power    factor : power('$1','$3').
+term -> term fn       factor : unwrap('$3').
+term -> factor		     : '$1'.
+
+factor -> float		     : unwrap('$1').
+factor -> open expr close    : '$2'.
+factor -> fn factor          : math(unwrap('$1'),'$2').
+factor -> fn                 : math(unwrap('$1')).
+    
+Erlang code.
+
+
+
+unwrap({_,_,V}) -> V;
+unwrap({_,V}) -> V;
+unwrap(V) -> V.
+
+add(A,B) ->
+    A+B.
+subtract(A,B) ->
+    A-B.
+divide(A,B) ->
+    A/B.
+multiply(A,B) ->
+    A*B.
+power(A,B) ->
+    math:pow(A,B).
+math(pi) ->
+    math:pi();
+math(Other) ->
+    io:format("Unknown operator ~p~n",[Other]),
+    0.0.
+math(sqrt,A) ->
+    math:sqrt(A);
+math(sin,A) ->
+    math:sin(A);
+math(cos,A) ->
+    math:cos(A);
+math(tan,A) ->
+    math:tan(A);
+math(asin,A) ->
+    math:asin(A);
+math(acos,A) ->
+    math:acos(A);
+math(atan,A) ->
+    math:atan(A);
+math(sinh,A) ->
+    math:sinh(A);
+math(cosh,A) ->
+    math:cosh(A);
+math(tanh,A) ->
+    math:tanh(A);
+math(asinh,A) ->
+    math:asinh(A);
+math(acosh,A) ->
+    math:acosh(A);
+math(atanh,A) ->
+    math:atanh(A);
+math(exp,A) ->
+    math:exp(A);
+math(log,A) ->
+    math:log(A);
+math(erf,A) ->
+    math:erf(A);
+math(erfc,A) ->
+    math:erfc(A);
+math(Other,_A) ->
+    io:format("Unknown operator ~p~n",[Other]),
+    0.0.

--- a/src/mathex_calc.erl
+++ b/src/mathex_calc.erl
@@ -1,0 +1,29 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%%   Evaluates string algebra expressions and simple formulas for
+%%%   timeseries data. Ported from babelstats project.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mathex_calc).
+
+%% API
+-export([eval/1, calculate/1]).
+
+%%--------------------------------------------------------------------
+%% @doc Evaluate an algebraic expression represented as a string.
+-spec eval(string()) -> float().
+%%--------------------------------------------------------------------
+eval(Algebra) ->
+    {ok, Ts, _} = calc_lexer:string(Algebra),
+    {ok, Result} = calc_parser:parse(Ts),
+    Result.
+
+%%--------------------------------------------------------------------
+%% @doc Evaluate a list of {Date, Expression} tuples.
+-spec calculate([{calendar:datetime(), string()}]) ->
+                 [{calendar:datetime(), float()}].
+%%--------------------------------------------------------------------
+calculate(Series) ->
+    lists:map(fun({Date, Expr}) ->
+                      {Date, eval(Expr)}
+              end, Series).

--- a/test/mathex_tests.erl
+++ b/test/mathex_tests.erl
@@ -39,3 +39,12 @@ single_element_safe_test() ->
     ?assertEqual(0.0, mathex:stdev_sample([1])),
     ?assertEqual(0.0, mathex:covariance([1],[1])),
     ?assertEqual(0.0, mathex:correlation([1],[1])).
+
+calc_eval_test() ->
+    ?assertEqual(10.0, mathex_calc:eval("5+5")).
+
+calc_series_test() ->
+    D1 = {{2024,1,1},{0,0,0}},
+    D2 = {{2024,1,2},{0,0,0}},
+    Series = mathex_calc:calculate([{D1,"1+1"},{D2,"2*3"}]),
+    ?assertEqual([{D1,2.0},{D2,6.0}], Series).


### PR DESCRIPTION
## Summary
- add parser and lexer from babelstats for simple arithmetic
- expose calculator API via `mathex_calc`
- document usage of new calculator module
- test calculator functions

## Testing
- `rebar3 eunit`

------
https://chatgpt.com/codex/tasks/task_e_68545b6d17948321adcd91aaa21161ca