### PR TITLE
Add standalone calc function and rename series calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This library contains the following functions:
 * correlation_matrix
 
 In addition to statistics, mathex can parse and evaluate simple algebraic
-expressions.  See `mathex_calc:eval/1` for evaluating a string expression and
-`mathex_calc:calculate/1` for applying an expression to a list of dated values.
+expressions.  See `mathex_calc:calc/1` for evaluating a string expression and
+`mathex_calc:calc_series/1` for applying an expression to a list of dated values.
   
 Most of these are well documented elsewhere except maybe the  
 correlation_matrix.  

--- a/src/mathex_calc.erl
+++ b/src/mathex_calc.erl
@@ -7,7 +7,7 @@
 -module(mathex_calc).
 
 %% API
--export([eval/1, calculate/1]).
+-export([eval/1, calc/1, calc_series/1]).
 
 %%--------------------------------------------------------------------
 %% @doc Evaluate an algebraic expression represented as a string.
@@ -19,11 +19,18 @@ eval(Algebra) ->
     Result.
 
 %%--------------------------------------------------------------------
+%% @doc Calculate a math expression and return the result.
+-spec calc(string()) -> float().
+%%--------------------------------------------------------------------
+calc(Expr) ->
+    eval(Expr).
+
+%%--------------------------------------------------------------------
 %% @doc Evaluate a list of {Date, Expression} tuples.
--spec calculate([{calendar:datetime(), string()}]) ->
+-spec calc_series([{calendar:datetime(), string()}]) ->
                  [{calendar:datetime(), float()}].
 %%--------------------------------------------------------------------
-calculate(Series) ->
+calc_series(Series) ->
     lists:map(fun({Date, Expr}) ->
                       {Date, eval(Expr)}
               end, Series).

--- a/test/mathex_tests.erl
+++ b/test/mathex_tests.erl
@@ -41,10 +41,10 @@ single_element_safe_test() ->
     ?assertEqual(0.0, mathex:correlation([1],[1])).
 
 calc_eval_test() ->
-    ?assertEqual(10.0, mathex_calc:eval("5+5")).
+    ?assertEqual(10.0, mathex_calc:calc("5+5")).
 
 calc_series_test() ->
     D1 = {{2024,1,1},{0,0,0}},
     D2 = {{2024,1,2},{0,0,0}},
-    Series = mathex_calc:calculate([{D1,"1+1"},{D2,"2*3"}]),
+    Series = mathex_calc:calc_series([{D1,"1+1"},{D2,"2*3"}]),
     ?assertEqual([{D1,2.0},{D2,6.0}], Series).


### PR DESCRIPTION
## Summary
- provide `mathex_calc:calc/1` for evaluating one formula
- rename `calculate/1` to `calc_series/1`
- update README and tests for the new function names

## Testing
- `rebar3 eunit`

------
https://chatgpt.com/codex/tasks/task_e_685502d999e483218f5a7dad6f391c6d